### PR TITLE
Fix inaccuracies in OOP and JS posts

### DIFF
--- a/public/content/posts/en/OOP.md
+++ b/public/content/posts/en/OOP.md
@@ -37,10 +37,10 @@ At the language level, privacy is implemented with the `#` symbol:
 
 ```js
 class Person {
-    #_privateField: 'value'
-    #_privateMethod () {}
+  #_privateField = "value";
+  #_privateMethod() {}
 }
-new Person()._privateField// undefined
+new Person().#_privateField; // SyntaxError
 ```
 
 ### Inheritance
@@ -115,5 +115,5 @@ class Talent extends User {
 
 const john = new Talent("John", "Smith", 30);
 //! 2. encapsulation (the private field isn't accessible outside the Talent class)
-john.#age; // undefined
+john.#age; // SyntaxError
 ```

--- a/public/content/posts/en/javascript.md
+++ b/public/content/posts/en/javascript.md
@@ -96,7 +96,7 @@ john = null; // перезаписываем ссылку на объект
 
 ### Hoisting - поднятие
 
-Декларация **функции и var** поднимается в начало кода со значением `undefined`
+Declarations are hoisted: `var` declarations are lifted and initialized with `undefined`, while function declarations are hoisted together with their implementation
 
 **do hoist**:
 
@@ -176,7 +176,7 @@ const clone = JSON.parse(JSON.stringify(originalObj));
 >
 > 2. Recursive copying implementation
 > 3. `lodash.deepClone`
-> 4. `window.structuredClonse` (modern browsers only)
+> 4. `window.structuredClone` (modern browsers only)
 >
 > - <span style="color:red;font-size:25px;">!!!</span> structuredClone can't copy methods
 

--- a/public/content/posts/ru/OOP.md
+++ b/public/content/posts/ru/OOP.md
@@ -37,10 +37,10 @@ isFeatured: true
 
 ```js
 class Person {
-    #_privateField: 'value'
-    #_privateMethod () {}
+  #_privateField = "value";
+  #_privateMethod() {}
 }
-new Person()._privateField// undefined
+new Person().#_privateField; // SyntaxError
 ```
 
 ### Наследование
@@ -115,5 +115,5 @@ class Talent extends User {
 
 const john = new Talent("John", "Smith", 30);
 //! 2. инкапсуляция (приватное поле недоступно вне класса Talent)
-john.#age; // undefined
+john.#age; // SyntaxError
 ```

--- a/public/content/posts/ru/javascript.md
+++ b/public/content/posts/ru/javascript.md
@@ -96,7 +96,7 @@ john = null; // перезаписываем ссылку на объект
 
 ### Hoisting - поднятие
 
-Декларация **функции и var** поднимается в начало кода со значением `undefined`
+При поднятии (hoisting) декларации `var` переменных поднимаются и инициализируются значением `undefined`, а объявления функций поднимаются вместе со своей реализацией
 
 **do hoist**:
 
@@ -176,7 +176,7 @@ const clone = JSON.parse(JSON.stringify(originalObj));
 >
 > 2. Recursive copying implementation
 > 3. `lodash.deepClone`
-> 4. `window.structuredClonse` (modern browsers only)
+> 4. `window.structuredClone` (modern browsers only)
 >
 > - <span style="color:red;font-size:25px;">!!!</span> structuredClone can't copy methods
 


### PR DESCRIPTION
## Summary
- Correct private field syntax and access examples in OOP articles
- Clarify hoisting and fix `structuredClone` typo in JavaScript articles

## Testing
- `npm run prettier:fix`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf0781ef2c8325841d451a3e657579